### PR TITLE
docs: add setup instructions and multi-origin CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,58 @@
-# README
+# Panda Gang Backend
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+Rails 8 API serving the [Panda Gang frontend](https://github.com/jholterh/panda-gang-frontend).
 
-Things you may want to cover:
+## Prerequisites
 
-* Ruby version
+- Ruby 3.3.3
+- PostgreSQL 14+
+- Bundler (`gem install bundler`)
 
-* System dependencies
+## Setup
 
-* Configuration
+```bash
+bundle install
+bin/rails db:create db:migrate db:seed
+```
 
-* Database creation
+## Starting the server
 
-* Database initialization
+```bash
+bin/rails server
+```
 
-* How to run the test suite
+This starts the API on **http://localhost:3000** (default Puma port).
 
-* Services (job queues, cache servers, search engines, etc.)
+### Matching the frontend port
 
-* Deployment instructions
+The backend only accepts requests from the origins defined in `FRONTEND_URL`. By default this is `http://localhost:5174` (see `config/initializers/cors.rb`).
 
-* ...
+Make sure your frontend dev server is actually running on that port. If it runs on a different port (e.g. `5173`), set the env var before starting the backend:
+
+```bash
+FRONTEND_URL=http://localhost:5173 bin/rails server
+```
+
+To allow multiple frontends at once (e.g. for testing), pass a comma-separated list:
+
+```bash
+FRONTEND_URL="http://localhost:5173,http://localhost:5174,http://localhost:5175" bin/rails server
+```
+
+On the frontend side, set `VITE_API_URL=http://localhost:3000` so it points at this backend.
+
+## Running tests
+
+```bash
+bin/rails test
+```
+
+Full CI suite (lint, security audit, tests, seeds):
+
+```bash
+bin/ci
+```
+
+## Architecture
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full system design, database schema, engine pattern, and API routes.

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,6 +1,6 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV.fetch("FRONTEND_URL", "http://localhost:5174")
+    origins(*ENV.fetch("FRONTEND_URL", "http://localhost:5174").split(",").map(&:strip))
     resource "*",
       headers: :any,
       methods: [ :get, :post, :put, :patch, :delete, :options ],


### PR DESCRIPTION
## Summary
- Rewrote README with prerequisites, setup, server start, and test instructions
- CORS now accepts comma-separated `FRONTEND_URL` to allow multiple frontends at once
- Documented how to match frontend/backend ports

## Test plan
- [ ] Verify `bin/rails server` starts on port 3000
- [ ] Set `FRONTEND_URL` with multiple origins and confirm CORS headers work for each

🤖 Generated with [Claude Code](https://claude.com/claude-code)